### PR TITLE
feat: Add flexible input parsing for types and scopes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,15 +19,15 @@ inputs:
     description: 'Comma separated list of allowed scopes (empty means no restriction)'
     required: false
 
-  breaking:
+  allow_breaking:
     description: 'Allow breaking changes (!) in title (true/false)'
     required: false
-    default: 'true'
+    default: true
 
   enforce_scopes:
     description: 'If true, enforce default or provided scopes. If false, allow any scope'
     required: false
-    default: 'false'
+    default: false
 
 outputs:
   valid:

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { validate, config } = require('../src/index');
+const { validate, config, parseList } = require('../src/index');
 
 test.describe('validate()', () => {
   test('rejects empty title', () => {
@@ -59,6 +59,16 @@ test.describe('validate()', () => {
     config.enforce_scopes = false;
   });
 
+  test('rejects when one of multiple scopes is invalid', () => {
+    config.enforce_scopes = true;
+    const validScope = config.scopes[0];
+    const title = `${config.types[0]}(${validScope}|badscope): msg`;
+    const result = validate(title);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /Scope "badscope"/);
+    config.enforce_scopes = false;
+  });
+
   test('handles breaking changes when allowed', () => {
     const title = `${config.types[0]}!: breaking stuff`;
     const result = validate(title);
@@ -74,10 +84,87 @@ test.describe('validate()', () => {
     config.allow_breaking = true;
   });
 
+  test('rejects BREAKING CHANGE type with exclamation', () => {
+    const title = 'BREAKING CHANGE!: overhaul';
+    const result = validate(title);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /must not include "!"/);
+  });
+
+  test('accepts BREAKING CHANGE type without exclamation', () => {
+    const title = 'BREAKING CHANGE: overhaul';
+    const result = validate(title);
+    assert.equal(result.valid, true);
+  });
+
   test('rejects empty message after colon', () => {
     const title = `${config.types[0]}:   `;
     const result = validate(title);
     assert.equal(result.valid, false);
     assert.match(result.reason, /empty/);
   });
+
+  test('rejects capitalized type', () => {
+    const title = 'Feat: add feature';
+    const result = validate(title);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /must be lowercase/);
+  });
+
+  test('rejects title with extra spaces trimmed', () => {
+    const validScope = config.scopes[0];
+    const title = ` ${config.types[0]} ( ${validScope} ) : spaced msg `;
+    const result = validate(title);
+    assert.equal(result.valid, false);
+    assert.match(result.reason, /not allowed/);
+  });
+});
+
+test.describe('parseList()', () => {
+  const cases = [
+    { input: 'a,b,c', expected: ['a', 'b', 'c'], desc: 'comma-separated' },
+    {
+      input: '"a","b","c"',
+      expected: ['a', 'b', 'c'],
+      desc: 'quoted comma-separated',
+    },
+    { input: 'a\nb\nc', expected: ['a', 'b', 'c'], desc: 'newline-separated' },
+    {
+      input: '[a, b, c]',
+      expected: ['a', 'b', 'c'],
+      desc: 'YAML-style inline array',
+    },
+    {
+      input: '  "x" ,  y ,  z  ',
+      expected: ['x', 'y', 'z'],
+      desc: 'trims whitespace and quotes',
+    },
+    { input: '', expected: [], desc: 'empty string to empty array' },
+    {
+      input: 'a,,b,\n,',
+      expected: ['a', 'b'],
+      desc: 'filters out empty items',
+    },
+    {
+      input: ['a', 'b'],
+      expected: ['a', 'b'],
+      desc: 'already an array to unchanged',
+    },
+    {
+      input: ' single ',
+      expected: ['single'],
+      desc: 'single value with spaces',
+    },
+    {
+      input: 'a|b|c',
+      expected: ['a', 'b', 'c'],
+      desc: 'pipe-separated list',
+    },
+  ];
+
+  for (const { input, expected, desc } of cases) {
+    test(`parses ${desc}`, () => {
+      assert.deepEqual(parseList(input), expected);
+    });
+  }
 });


### PR DESCRIPTION
This PR introduces **flexible input parsing** for the `types` and `scopes` options in the Sheriff GitHub Action.
A new `parseList` utility has been added to normalize inputs into arrays, supporting multiple styles:

* **Comma-separated** → `feat,fix,docs`
* **Pipe-separated** → `feat|fix|docs`
* **YAML array** → `[feat, fix, docs]`
* **JSON array** → `'["feat","fix","docs"]'`
* **Multiline block (`|`)**

Additional changes:

* Updated `README.md` with detailed usage examples
* Updated `action.yml` input descriptions
* Refactored input handling in `src/index.js` to use `parseList`
* Added comprehensive tests for parsing and validation edge cases
* renamed input `breaking` → `allow_breaking` (migration required)

This improves **DX (developer experience)** by letting users choose whichever YAML style fits their workflow.
